### PR TITLE
add_paco-paco

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
         <label for="taktTime">Takt Time (segundos):</label>
         <input type="number" id="taktTime" value="45" min="1">
         <span class="separator">|</span>
+        <button id="goToPacoPacoBtn">Ir para Paco-Paco</button>
     </div>
 
     <div class="main-layout-container">

--- a/paco-paco-script.js
+++ b/paco-paco-script.js
@@ -1,0 +1,397 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const pacoPacoPostosContainer = document.getElementById('paco-paco-postos-container');
+    const pacoGlobalOtPalette = document.getElementById('paco-global-ot-palette');
+
+    let draggedPacoOt = null;
+    let otElementsMap = new Map(); // Mapa para armazenar referências aos elementos OT com seu HTML completo
+    let pacoPacoCavityContents = {}; // Armazena o estado das cavidades da página Paco-Paco: { postoId: { cavityId: otId } }
+    let pacoPacoAvailableOts = new Set(); // OTs atualmente visíveis na paleta global
+    let pacoPacoGridDimensions = {}; // Armazena as dimensões do grid para cada posto: { postoId: { cols: X, rows: Y } }
+
+    const SOLDER_OTS = [ // Lista de OTs de Solda, se necessário para lógica específica
+        'ot0344', 'ot0300', 'ot0301', 'ot0302', 'ot0311', 'ot0304', 'ot0342', 'ot0343',
+        'ot0305', 'ot0312', 'ot0190', 'ot0229', 'ot0192', 'ot0332', 'ot0333', 'ot0334',
+        'ot0193', 'ot0310', 'ot0309', 'ot0335', 'ot0336', 'ot0337'
+    ];
+    const SOLDER_OTS_SET = new Set(SOLDER_OTS);
+
+    function loadInitialData() {
+        // Carregar otElementsMap do sessionStorage (em HTML string)
+        const storedOtElementsMapHTML = sessionStorage.getItem('otElementsMapHTML');
+        if (storedOtElementsMapHTML) {
+            const parsedMap = JSON.parse(storedOtElementsMapHTML);
+            for (const otId in parsedMap) {
+                const tempDiv = document.createElement('div');
+                tempDiv.innerHTML = parsedMap[otId];
+                otElementsMap.set(otId, tempDiv.firstChild);
+            }
+        }
+
+        // Carregar o estado salvo das cavidades
+        const savedCavityContents = sessionStorage.getItem('pacoPacoCavityContents');
+        if (savedCavityContents) {
+            pacoPacoCavityContents = JSON.parse(savedCavityContents);
+        } else {
+            pacoPacoCavityContents = {};
+        }
+
+        // Carregar OTs disponíveis na paleta global
+        const savedAvailableOts = sessionStorage.getItem('pacoPacoAvailableOts');
+        if (savedAvailableOts) {
+            pacoPacoAvailableOts = new Set(JSON.parse(savedAvailableOts));
+        } else {
+            // Se não houver estado salvo, todas as OTs são inicialmente disponíveis
+            const allOtIdsFromMain = JSON.parse(sessionStorage.getItem('allOtIds') || '[]');
+            pacoPacoAvailableOts = new Set(allOtIdsFromMain);
+        }
+
+        // Carregar as dimensões do grid
+        const savedGridDimensions = sessionStorage.getItem('pacoPacoGridDimensions');
+        if (savedGridDimensions) {
+            pacoPacoGridDimensions = JSON.parse(savedGridDimensions);
+        } else {
+            pacoPacoGridDimensions = {}; // Default vazio
+        }
+    }
+
+    function savePacoPacoState() {
+        sessionStorage.setItem('pacoPacoCavityContents', JSON.stringify(pacoPacoCavityContents));
+        sessionStorage.setItem('pacoPacoAvailableOts', JSON.stringify(Array.from(pacoPacoAvailableOts)));
+        sessionStorage.setItem('pacoPacoGridDimensions', JSON.stringify(pacoPacoGridDimensions));
+    }
+
+    function populateGlobalPacoPalette() {
+        pacoGlobalOtPalette.innerHTML = '<h2>Todas as OTs</h2>'; // Limpa e adiciona o título
+        
+        // Criar um container flex para as OTs na paleta
+        const otContainer = document.createElement('div');
+        otContainer.classList.add('paco-palette-ots-global-container');
+        pacoGlobalOtPalette.appendChild(otContainer);
+
+        // Adicionar as OTs disponíveis à paleta global
+        otElementsMap.forEach((otElement, otId) => {
+            // Verifica se a OT está marcada como disponível para esta paleta
+            if (pacoPacoAvailableOts.has(otId)) {
+                const draggableOt = otElement.cloneNode(true);
+                draggableOt.classList.add('paco-ot-draggable');
+                draggableOt.id = `paco-palette-global-${otId}`; // ID único na paleta global
+                draggableOt.dataset.originalOtId = otId; // Referência ao ID original
+
+                draggableOt.addEventListener('dragstart', (e) => {
+                    draggedPacoOt = e.target;
+                    e.dataTransfer.setData('text/plain', draggableOt.dataset.originalOtId);
+                    draggableOt.classList.add('dragging');
+                });
+                draggableOt.addEventListener('dragend', () => {
+                    draggableOt.classList.remove('dragging');
+                    draggedPacoOt = null;
+                });
+                otContainer.appendChild(draggableOt);
+            }
+        });
+    }
+
+    function createPacoPacoPostoSection(postoId) {
+        const postoSection = document.createElement('div');
+        postoSection.classList.add('paco-posto-section');
+        postoSection.id = `paco-${postoId}`;
+
+        const postoTitle = document.createElement('h2');
+        postoTitle.textContent = `Paco-Paco - ${postoId.replace('posto-', '').replace('p', 'Posto ').replace('solda-01', 'Posto de Solda 01')}`;
+        postoSection.appendChild(postoTitle);
+
+        const contentWrapper = document.createElement('div');
+        contentWrapper.classList.add('paco-posto-content-wrapper');
+        postoSection.appendChild(contentWrapper);
+
+        // Controles de dimensão do grid
+        const gridControls = document.createElement('div');
+        gridControls.classList.add('paco-grid-controls');
+
+        const labelCols = document.createElement('label');
+        labelCols.textContent = 'Colunas:';
+        const inputCols = document.createElement('input');
+        inputCols.type = 'number';
+        inputCols.min = '1';
+        inputCols.value = pacoPacoGridDimensions[postoId]?.cols || 20; // Valor padrão
+        inputCols.id = `input-cols-${postoId}`;
+
+        const labelRows = document.createElement('label');
+        labelRows.textContent = 'Linhas:';
+        const inputRows = document.createElement('input');
+        inputRows.type = 'number';
+        inputRows.min = '1';
+        inputRows.value = pacoPacoGridDimensions[postoId]?.rows || 4; // Valor padrão (para 40 slots)
+        inputRows.id = `input-rows-${postoId}`;
+
+        const generateGridBtn = document.createElement('button');
+        generateGridBtn.textContent = 'Gerar Slots';
+        generateGridBtn.addEventListener('click', () => {
+            const newCols = parseInt(inputCols.value);
+            // CORREÇÃO: Usar inputRows.value para newRows
+            const newRows = parseInt(inputRows.value); 
+            if (newCols > 0 && newRows > 0) {
+                pacoPacoGridDimensions[postoId] = { cols: newCols, rows: newRows };
+                savePacoPacoState();
+                populatePacoGrid(postoId, gridArea);
+            } else {
+                alert('Colunas e Linhas devem ser maiores que zero.');
+            }
+        });
+
+        gridControls.appendChild(labelCols);
+        gridControls.appendChild(inputCols);
+        gridControls.appendChild(labelRows);
+        gridControls.appendChild(inputRows);
+        gridControls.appendChild(generateGridBtn);
+        contentWrapper.appendChild(gridControls);
+
+        // Grid/Área das cavidades
+        const gridArea = document.createElement('div');
+        gridArea.classList.add('paco-paco-grid-area-local');
+        contentWrapper.appendChild(gridArea);
+
+        // Popula o grid com base nas dimensões salvas ou padrão
+        populatePacoGrid(postoId, gridArea);
+
+        return postoSection;
+    }
+
+    function populatePacoGrid(postoId, gridAreaElement) {
+        // Limpa o grid para recriação
+        gridAreaElement.innerHTML = '';
+
+        const cols = pacoPacoGridDimensions[postoId]?.cols || 20;
+        const rows = pacoPacoGridDimensions[postoId]?.rows || 4;
+        const numCavities = cols * rows;
+
+        gridAreaElement.style.gridTemplateColumns = `repeat(${cols}, 1fr)`;
+        gridAreaElement.style.gridTemplateRows = `repeat(${rows}, 1fr)`; 
+        
+        // Garante que o objeto para o posto exista no pacoPacoCavityContents
+        // MANTEMOS A INICIALIZAÇÃO AQUI, pois populatePacoGrid é chamado para preencher o grid
+        if (!pacoPacoCavityContents[postoId]) {
+            pacoPacoCavityContents[postoId] = {};
+        } else {
+            // Ao repopular o grid, também limpamos o conteúdo salvo para este posto
+            // e o reconstruímos com base nas OTs que ainda estão dentro dos novos limites do grid.
+            // Isso evita que referências a cavidades antigas (fora dos novos limites) permaneçam no estado.
+            pacoPacoCavityContents[postoId] = {};
+        }
+
+
+        let currentCavityIndex = 0;
+        const newCavityContentsForPosto = {}; // Este será o novo estado para o posto atual
+
+        for (let i = 0; i < numCavities; i++) {
+            const cavityId = `paco-cavity-${postoId}-${i}`; // Garante ID baseado no índice
+
+            const cavity = document.createElement('div');
+            cavity.classList.add('paco-paco-cavity-local');
+            cavity.id = cavityId;
+
+            const cavityLabel = document.createElement('span');
+            cavityLabel.classList.add('paco-cavity-label');
+            
+            // Lógica para o novo formato de nome da slot (A01, B02, etc.)
+            const row_index_from_top = Math.floor(i / cols); // Índice da linha (0-indexed, de cima para baixo)
+            const col_number = (i % cols) + 1; // Número da coluna (1-indexed)
+
+            // Calcula o índice da linha de baixo para cima
+            const row_index_from_bottom = (rows - 1) - row_index_from_top;
+            // Converte o índice da linha (0=A, 1=B, ...) para a letra correspondente
+            const row_letter = String.fromCharCode('A'.charCodeAt(0) + row_index_from_bottom);
+
+            // Formata o número da coluna com dois dígitos (ex: 1 -> 01)
+            const formatted_col_number = String(col_number).padStart(2, '0');
+
+            cavityLabel.textContent = `${row_letter}${formatted_col_number}`;
+            // Fim da lógica para o nome da slot
+
+            cavity.appendChild(cavityLabel);
+
+            // Tenta popular a cavidade se houver dados salvos OU se uma OT foi "desalocada"
+            // Pega do estado salvo antes da reconstrução do grid
+            const otIdInSavedCavity = JSON.parse(sessionStorage.getItem('pacoPacoCavityContents') || '{}')[postoId]?.[cavityId];
+
+            if (otIdInSavedCavity) {
+                const otElement = otElementsMap.get(otIdInSavedCavity);
+                if (otElement) {
+                    const otCopy = otElement.cloneNode(true);
+                    otCopy.classList.add('paco-ot-in-cavity');
+                    otCopy.draggable = true; // Permite arrastar para fora
+                    otCopy.id = `paco-in-cavity-${otIdInSavedCavity}`; // ID único para a OT na cavidade
+                    otCopy.dataset.originalOtId = otIdInSavedCavity;
+                    
+                    cavity.appendChild(otCopy);
+                    cavity.classList.add('has-ot');
+
+                    newCavityContentsForPosto[cavityId] = otIdInSavedCavity; // Adiciona ao novo estado do posto
+                    
+                    // Adiciona listener para remover OT da cavidade (clique)
+                    otCopy.addEventListener('click', (e) => {
+                        e.stopPropagation(); // Evita que o clique se propague para a cavidade
+                        removeOtFromCavity(postoId, cavity.id, otIdInSavedCavity, cavity, otCopy);
+                    });
+
+                    // Permite arrastar para fora da cavidade
+                    otCopy.addEventListener('dragstart', (e) => {
+                        draggedPacoOt = e.target;
+                        e.dataTransfer.setData('text/plain', otCopy.dataset.originalOtId);
+                        otCopy.classList.add('dragging');
+                    });
+                    otCopy.addEventListener('dragend', () => {
+                        otCopy.classList.remove('dragging');
+                        draggedPacoOt = null;
+                    });
+                } else {
+                    // OT não encontrada no mapa (WTF?), move de volta para a paleta
+                    pacoPacoAvailableOts.add(otIdInSavedCavity);
+                }
+            }
+
+            cavity.addEventListener('dragover', (e) => {
+                e.preventDefault();
+                // Permite drop se houver uma OT sendo arrastada E a cavidade estiver vazia
+                if (draggedPacoOt && !cavity.querySelector('.paco-ot-in-cavity')) {
+                    cavity.classList.add('drag-over');
+                } else {
+                    cavity.classList.remove('drag-over');
+                }
+            });
+
+            cavity.addEventListener('dragleave', () => {
+                cavity.classList.remove('drag-over');
+            });
+
+            cavity.addEventListener('drop', (e) => {
+                e.preventDefault();
+                cavity.classList.remove('drag-over');
+
+                if (draggedPacoOt && !cavity.querySelector('.paco-ot-in-cavity')) {
+                    const originalOtId = e.dataTransfer.getData('text/plain');
+                    const sourceOtElement = document.getElementById(`paco-palette-global-${originalOtId}`) || document.getElementById(`paco-in-cavity-${originalOtId}`);
+
+                    if (sourceOtElement) {
+                        // Se a OT veio de outra cavidade, remove-a de lá primeiro
+                        const previousCavity = sourceOtElement.closest('.paco-paco-cavity-local');
+                        if (previousCavity) {
+                            const prevPostoId = previousCavity.closest('.paco-posto-section').id.replace('paco-', '');
+                            const prevOtId = sourceOtElement.dataset.originalOtId;
+                            removeOtFromCavity(prevPostoId, previousCavity.id, prevOtId, previousCavity, sourceOtElement);
+                        } else {
+                            // Se veio da paleta global, esconde da paleta
+                            sourceOtElement.style.display = 'none';
+                            pacoPacoAvailableOts.delete(originalOtId);
+                        }
+                        
+                        const otCopy = otElementsMap.get(originalOtId).cloneNode(true);
+                        otCopy.classList.add('paco-ot-in-cavity');
+                        otCopy.draggable = true; // Permite arrastar para fora
+                        otCopy.id = `paco-in-cavity-${originalOtId}`;
+                        otCopy.dataset.originalOtId = originalOtId;
+
+                        cavity.appendChild(otCopy);
+                        cavity.classList.add('has-ot');
+
+                        // CORREÇÃO: Garante que o objeto do posto exista antes de tentar adicionar a cavidade
+                        if (!pacoPacoCavityContents[postoId]) { 
+                            pacoPacoCavityContents[postoId] = {};
+                        }
+                        pacoPacoCavityContents[postoId][cavity.id] = originalOtId; 
+
+                        savePacoPacoState();
+                        populateGlobalPacoPalette(); // Atualiza a paleta global para refletir a OT ausente
+
+                        // Adiciona listener para remover OT da cavidade (clique)
+                        otCopy.addEventListener('click', (e) => {
+                            e.stopPropagation();
+                            removeOtFromCavity(postoId, cavity.id, originalOtId, cavity, otCopy);
+                        });
+
+                        // Permite arrastar para fora da cavidade
+                        otCopy.addEventListener('dragstart', (e) => {
+                            draggedPacoOt = e.target;
+                            e.dataTransfer.setData('text/plain', otCopy.dataset.originalOtId);
+                            otCopy.classList.add('dragging');
+                        });
+                        otCopy.addEventListener('dragend', () => {
+                            otCopy.classList.remove('dragging');
+                            draggedPacoOt = null;
+                        });
+                    }
+                }
+            });
+
+            gridAreaElement.appendChild(cavity);
+        }
+        // Ao final de popularPacoGrid, salvamos o novo estado reconstruído
+        // Isso resolve o problema de limpar corretamente os elementos que ficam fora do grid
+        pacoPacoCavityContents[postoId] = newCavityContentsForPosto;
+        savePacoPacoState();
+        populateGlobalPacoPalette(); // Garante que a paleta global reflita as OTs desalocadas
+    }
+
+    function removeOtFromCavity(postoId, cavityId, otId, cavityElement, otElement) {
+        cavityElement.removeChild(otElement);
+        cavityElement.classList.remove('has-ot');
+
+        // Remover do estado
+        if (pacoPacoCavityContents[postoId]) {
+            delete pacoPacoCavityContents[postoId][cavityId];
+            // CORREÇÃO: Não deletar o objeto do posto se ele ficar vazio, apenas se não houver mais chaves
+            // Isso garante que pacoPacoCavityContents[postoId] nunca seja 'undefined'
+            if (Object.keys(pacoPacoCavityContents[postoId]).length === 0) {
+                 // Pode deixar vazio ou deletar, desde que a lógica de drop lide com 'undefined' corretamente
+                 // Optamos por deixar vazio e garantir inicialização no drop.
+            }
+        }
+        pacoPacoAvailableOts.add(otId); // Torna a OT disponível novamente na paleta global
+        savePacoPacoState();
+
+        // Faz a OT reaparecer na paleta global
+        populateGlobalPacoPalette(); 
+    }
+
+
+    function initializePacoPacoPage() {
+        loadInitialData();
+        pacoPacoPostosContainer.innerHTML = ''; // Limpa o container antes de popular
+
+        populateGlobalPacoPalette(); // Popula a paleta global primeiro
+
+        // Determina quantos postos Paco-Paco mostrar com base na aba principal
+        const numPostosPrincipal = parseInt(localStorage.getItem('numPostos') || '4');
+        let postoIds = [];
+        // Adiciona o posto de solda
+        postoIds.push('posto-solda-01');
+        // Adiciona os postos numerados
+        for (let i = 1; i <= numPostosPrincipal; i++) {
+            postoIds.push(`posto-p${String(i).padStart(2, '0')}`);
+        }
+
+        const sortedPostoIds = postoIds.sort((a, b) => {
+            const isA_Solda = a === 'posto-solda-01';
+            const isB_Solda = b === 'posto-solda-01';
+
+            if (isA_Solda && !isB_Solda) return -1;
+            if (!isA_Solda && isB_Solda) return 1;
+            if (isA_Solda && isB_Solda) return 0;
+
+            const numA = parseInt(a.replace('posto-p', ''));
+            const numB = parseInt(b.replace('posto-p', ''));
+            return numA - numB;
+        });
+
+        if (sortedPostoIds.length === 0) {
+            pacoPacoPostosContainer.innerHTML = '<p>Nenhum posto configurado para Paco-Paco.</p>';
+        } else {
+            sortedPostoIds.forEach(postoId => {
+                const postoSection = createPacoPacoPostoSection(postoId);
+                pacoPacoPostosContainer.appendChild(postoSection);
+            });
+        }
+    }
+
+    initializePacoPacoPage();
+});

--- a/paco-paco.html
+++ b/paco-paco.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Paco-Paco - Simulação de Sub-Montagem</title>
+    <link rel="stylesheet" href="style.css">
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <h1>Paco-Paco - Simulação de Distribuição</h1>
+
+    <div class="main-layout-container">
+        <div class="left-panel ot-palette" id="paco-global-ot-palette">
+            <h2>Todas as OTs</h2>
+            </div>
+
+        <div class="center-panel postos-area" id="paco-paco-postos-container">
+            </div>
+        
+        <div class="right-panel">
+            </div>
+    </div>
+
+    <script src="paco-paco-script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -393,6 +393,18 @@ document.addEventListener('DOMContentLoaded', () => {
 
                 syncOtPaletteVisibility();
                 console.log("Estado da simulação carregado com sucesso!");
+
+                // Salvar allOtIds no sessionStorage ao carregar o estado
+                sessionStorage.setItem('allOtIds', JSON.stringify(Array.from(initialOtOrder)));
+                
+                // Recriar e salvar otElementsMap no sessionStorage
+                const tempOtElementsMap = {};
+                otElementsMap.forEach((value, key) => {
+                    tempOtElementsMap[key] = value.outerHTML;
+                });
+                sessionStorage.setItem('otElementsMapHTML', JSON.stringify(tempOtElementsMap));
+
+
                 return true;
             }
             return false;
@@ -405,6 +417,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     function clearSavedState() {
         localStorage.clear();
+        sessionStorage.clear(); // Limpa também o sessionStorage
         console.log("Estado salvo limpo.");
     }
 
@@ -641,7 +654,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
                     const originLabel = document.createElement('span');
                     originLabel.classList.add('origin-label');
-                    originLabel.textContent = sourcePostoId.startsWith('posto-p') ? `P${sourcePostoNumber}` : postoId; // Changed to postoId
+                    originLabel.textContent = sourcePostoId.startsWith('posto-p') ? `P${sourcePostoNumber}` : postoSoldaId.replace('posto-', ''); // Changed to postoId
                     targetSlot.appendChild(originLabel);
 
                     const targetConectorId = targetConectorElement.id;
@@ -786,6 +799,7 @@ document.addEventListener('DOMContentLoaded', () => {
             otsByPostoForSessionStorage[postoId] = Array.from(originalOtsByPosto[postoId]);
         }
         sessionStorage.setItem('allOriginalOtsByPosto', JSON.stringify(otsByPostoForSessionStorage));
+        sessionStorage.setItem('otOriginalOwners', JSON.stringify(Object.fromEntries(Object.entries(otOriginalOwners).map(([key, value]) => [key, value]))));
         console.log("OTs originais por posto atualizadas para a nova aba:", otsByPostoForSessionStorage);
     }
 
@@ -887,6 +901,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 const isChecked = e.target.checked;
                 let timeChange = 0;
                 let actionDescription = "";
+                const type = conectorDiv.dataset.connectorType;
 
                 if (isChecked) {
                     timeChange += TIME_LOCK_CONNECTOR;
@@ -1195,6 +1210,15 @@ document.addEventListener('DOMContentLoaded', () => {
         if (reportArea) reportArea.innerHTML = '';
         updateOriginalOtsByPosto();
         saveAppState();
+
+        // Salvar allOtIds no sessionStorage quando os postos são gerados
+        sessionStorage.setItem('allOtIds', JSON.stringify(Array.from(initialOtOrder)));
+        // Recriar e salvar otElementsMap no sessionStorage
+        const tempOtElementsMap = {};
+        otElementsMap.forEach((value, key) => {
+            tempOtElementsMap[key] = value.outerHTML;
+        });
+        sessionStorage.setItem('otElementsMapHTML', JSON.stringify(tempOtElementsMap));
     }
 
     function generateConnectorPalette() {
@@ -1814,7 +1838,18 @@ document.addEventListener('DOMContentLoaded', () => {
 
         goToPacoPacoBtn.addEventListener('click', () => {
             console.log("Botão 'Ir para Paco-Paco' clicado.");
-            sessionStorage.removeItem('selectedPacoPostoIdForTab');
+            sessionStorage.removeItem('selectedPacoPostoIdForTab'); // This might be for a different flow, keeping it for now.
+            updateOriginalOtsByPosto(); // Ensure latest data is saved
+
+            // Salvar allOtIds no sessionStorage quando os postos são gerados
+            sessionStorage.setItem('allOtIds', JSON.stringify(Array.from(initialOtOrder)));
+            // Recriar e salvar otElementsMap no sessionStorage
+            const tempOtElementsMap = {};
+            otElementsMap.forEach((value, key) => {
+                tempOtElementsMap[key] = value.outerHTML;
+            });
+            sessionStorage.setItem('otElementsMapHTML', JSON.stringify(tempOtElementsMap));
+
             window.open('paco-paco.html', '_blank');
         });
 

--- a/style.css
+++ b/style.css
@@ -125,7 +125,7 @@ h2 {
     display: flex;
     gap: 25px;
     width: 100%;
-    max-width: 95vw;
+    max-width: 100vw; /* ALTERADO: Removido o limite de 95vw para 100vw */
     background-color: #222;
     border-radius: 12px;
     box-shadow: 0 8px 25px rgba(0, 0, 0, 0.4);
@@ -152,6 +152,11 @@ h2 {
     overflow-y: auto; /* Habilita a barra de rolagem interna */
 }
 
+/* NOVO: Remove a borda do painel direito */
+.right-panel {
+    border: none;
+}
+
 
 /* Regras para organizar as OTs em duplas/grupos */
 .ot-palette {
@@ -161,6 +166,15 @@ h2 {
     gap: 0; /* Remove o espaçamento global entre os itens, pois o .ot-group já lida com isso */
     align-content: flex-start;
 }
+/* NOVO: Estilo para o container de OTs dentro da paleta global do Paco-Paco */
+.paco-palette-ots-global-container {
+    display: flex;
+    flex-wrap: wrap; /* Permite que as OTs quebrem linha */
+    gap: 10px; /* Espaço entre as OTs */
+    justify-content: center; /* Centraliza as OTs */
+    padding: 10px 0;
+}
+
 
 .ot-group {
     display: flex; /* Habilita o Flexbox para organizar as OTs dentro do grupo */
@@ -428,7 +442,7 @@ h2 {
     width: 100%;
     height: 100%; /* Imagem ocupa 100% da área do conector */
     object-fit: contain;
-    position: absolute; /* Posiciona a imagem como background */
+    position: absolute;
     top: 0;
     left: 0;
     z-index: 1; /* Fica atrás de slots e checkbox */
@@ -901,21 +915,19 @@ h2 {
 
 
 /* NOVO: Estilos para a página Paco-Paco (paco-paco.html) */
-#paco-paco-postos-container {
-    display: flex;
-    flex-wrap: wrap; /* Permite que os blocos de posto quebrem linha */
-    gap: 30px;
-    width: 100%;
-    max-width: 95vw;
-    margin-top: 20px;
-    padding: 30px;
-    background-color: #222;
-    border-radius: 12px;
-    box-shadow: 0 8px 25px rgba(0, 0, 0, 0.4);
-    justify-content: center; /* Centraliza os blocos de posto */
-    align-items: flex-start;
+/* A area de postos do Paco-Paco (center-panel e postos-area no paco-paco.html) usará os mesmos estilos da aba principal */
+#paco-paco-postos-container.postos-area { /* Adicionado .postos-area */
+    display: flex; /* Garante flexbox */
+    flex-wrap: wrap; /* Permite que os itens quebrem linha */
+    gap: 30px; /* Espaçamento entre os postos */
+    width: 100%; /* Ocupa toda a largura do seu pai (.center-panel) */
+    /* Removido max-width/margin-top/padding/background/box-shadow pois são controlados pelo .center-panel pai */
+    justify-content: flex-start; /* Alinha os itens ao início */
+    align-items: flex-start; /* Alinha os itens ao topo */
+    min-height: auto; /* Deixa a altura se ajustar ao conteúdo */
 }
 
+/* Estilo para cada seção de posto INDIVIDUAL (o "quadrante" do Paco-Paco) */
 .paco-posto-section {
     border: 1px solid var(--medium-gray);
     background-color: #333;
@@ -925,11 +937,26 @@ h2 {
     display: flex;
     flex-direction: column;
     gap: 15px;
-    flex-basis: calc(50% - 15px); /* Ocupa cerca de metade da largura, com espaço entre */
-    max-width: calc(50% - 15px);
+    
+    /* Ajustes para aumentar o tamanho do quadrante */
+    flex-grow: 1; /* Permite que cresça para preencher o espaço disponível */
+    flex-basis: 95%; /* Tenta ocupar quase toda a largura disponível */
+    max-width: 100%; /* Permite que ocupe 100% se necessário */
+    min-width: 1300px; /* Mantém um mínimo grande para não encolher muito */
+    
     box-sizing: border-box; /* Inclui padding e border na largura */
-    min-width: 600px; /* Largura mínima para o posto completo do Paco-Paco */
+    min-height: 600px; /* Aumentado a altura mínima do quadrante */
 }
+
+/* Isso fará com que em telas grandes, tente duas colunas. Em telas menores, flex-basis: 100% fará uma coluna. */
+@media (min-width: 1500px) { /* Exemplo: Ajusta para telas muito grandes */
+    .paco-posto-section {
+        /* Para telas muito grandes, pode tentar alinhar 2 colunas */
+        max-width: calc(50% - 15px); /* Tenta 2 colunas com gap */
+        flex-basis: calc(50% - 15px); /* Garante que se ajustem em duas colunas */
+    }
+}
+
 
 .paco-posto-section h2 {
     color: var(--primary-red);
@@ -942,24 +969,62 @@ h2 {
 
 .paco-posto-content-wrapper {
     display: flex;
-    gap: 20px;
+    flex-direction: column; /* Alterado para empilhar controles e grid */
+    gap: 15px; /* Espaço entre controles e grid */
     width: 100%;
-    align-items: flex-start;
+    
+    /* NOVO: Permite que o wrapper do conteúdo cresça e preencha a altura restante */
+    flex-grow: 1;
 }
 
-.paco-paco-palette-local {
-    width: 180px; /* Largura fixa para a paleta de OTs do posto */
-    flex-shrink: 0;
-    border: 1px dashed #555;
+/* NOVO: Estilos para os controles de dimensão do Paco-Paco */
+.paco-grid-controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    align-items: center;
+    margin-bottom: 10px;
+    justify-content: center; /* Centraliza os controles */
+    width: 100%;
+}
+
+.paco-grid-controls label {
+    font-size: 0.9em;
+    color: var(--light-text);
+    font-weight: bold;
+}
+
+.paco-grid-controls input[type="number"] {
+    width: 60px;
+    padding: 5px 8px;
+    border-radius: 5px;
+    border: 1px solid #555;
     background-color: #2a2a2a;
-    padding: 10px;
-    border-radius: 8px;
-    max-height: 400px; /* Altura máxima para a paleta com scroll */
-    overflow-y: auto;
-    box-shadow: inset 0 0 5px rgba(0,0,0,0.1);
+    color: var(--light-text);
+    font-size: 0.9em;
+    text-align: center;
 }
 
-.paco-paco-palette-local h3 {
+.paco-grid-controls button {
+    padding: 6px 12px;
+    border-radius: 5px;
+    border: none;
+    background-color: var(--primary-red);
+    color: white;
+    font-size: 0.9em;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+.paco-grid-controls button:hover {
+    background-color: var(--secondary-red);
+}
+
+
+/* REMOVIDO: .paco-paco-palette-local não existe mais como paleta individual */
+/* Se você quiser uma paleta local para cada posto no futuro, precisará recriar e reestilizar. */
+
+.paco-paco-palette-local h3 { /* Mantido para não quebrar se algo usar, mas não é mais a paleta principal */
     color: var(--light-text);
     margin-top: 0;
     margin-bottom: 10px;
@@ -967,48 +1032,59 @@ h2 {
     text-align: center;
 }
 
-.paco-palette-ots {
+.paco-palette-ots { /* Mantido para não quebrar se algo usar, mas não é mais a paleta principal */
     display: flex;
     flex-wrap: wrap; /* Permite que as OTs quebrem linha na paleta */
     gap: 10px;
     justify-content: center;
 }
 
+/* Estilo para as OTs na paleta GLOBAL do Paco-Paco */
 .paco-ot-draggable {
-    width: 50px;
-    height: 50px;
-    border: 2px solid transparent;
-    border-radius: 5px;
+    width: 80px; /* Mantido o tamanho da OT na paleta global */
+    height: 80px; /* Mantido o tamanho da OT na paleta global */
+    border-radius: 8px;
     cursor: grab;
-    transition: border-color 0.15s, transform 0.15s;
+    border: 2px solid transparent; /* Adicionado border para hover */
+    transition: transform 0.15s ease-in-out, border-color 0.2s, box-shadow 0.2s;
     object-fit: contain;
     background-color: #3a3a3a;
     box-shadow: 0 2px 5px rgba(0,0,0,0.2);
 }
 
-.paco-ot-draggable:hover {
-    border-color: var(--primary-red);
-    transform: translateY(-2px);
+.paco-ot-draggable:active {
+    cursor: grabbing;
+    transform: scale(1.1);
+    box-shadow: 0 5px 15px rgba(0,0,0,0.3);
 }
 
 .paco-ot-draggable.dragging {
     opacity: 0.6;
     border-color: var(--primary-red);
     box-shadow: 0 4px 8px rgba(var(--primary-red-rgb), 0.3);
+    transform: scale(0.95);
+}
+
+.paco-ot-draggable:hover {
+    border-color: var(--primary-red);
+    transform: translateY(-2px);
+    box-shadow: 0 6px 12px rgba(0,0,0,0.25);
 }
 
 .paco-paco-grid-area-local {
-    flex-grow: 1;
+    flex-grow: 1; /* NOVO: Faz o grid crescer e preencher o espaço restante */
     border: 2px dashed var(--primary-red);
     background-color: #2a2a2a;
-    padding: 10px;
+    padding: 5px; /* Aumentado o padding interno do grid */
     border-radius: 8px;
     display: grid;
     /* grid-template-columns e grid-template-rows definidos no JS */
-    gap: 3px; /* Espaço entre as cavidades */
+    gap: 8px; /* Aumentado ainda mais o espaçamento entre slots */
     box-shadow: inset 0 0 10px rgba(0,0,0,0.2);
     overflow: auto; /* Rolagem se o grid for muito grande */
-    min-width: 400px; /* Largura mínima para o grid de 10 colunas x 40px */
+    
+    /* A altura mínima será controlada pelo número de linhas e a altura de cada linha no JS */
+    /* Removido min-height fixo daqui, pois agora ele crescerá flexivelmente */
 }
 
 .paco-paco-cavity-local {
@@ -1020,6 +1096,7 @@ h2 {
     border-radius: 3px;
     transition: background-color 0.1s, border-color 0.1s;
     box-sizing: border-box;
+    /* Remover width/height fixos para que o tamanho seja ditado pelo grid-template-columns/rows */
 }
 
 .paco-paco-cavity-local.drag-over {
@@ -1033,17 +1110,35 @@ h2 {
     border-color: #28a745;
 }
 
+/* Estilo para as OTs dentro das cavidades do Paco-Paco */
 .paco-ot-in-cavity {
-    width: 90%;
-    height: 90%;
+    width: 90%; /* OT preenche 90% do slot */
+    height: 90%; /* OT preenche 90% do slot */
     object-fit: contain;
     cursor: pointer; /* Permite clicar para remover */
+    /* Garante que o arrasto funcione a partir da imagem na cavidade */
+    transition: opacity 0.2s, transform 0.2s; 
+}
+/* Estilos para quando a OT dentro da cavidade é arrastada */
+.paco-ot-in-cavity.dragging {
+    opacity: 0.7;
+    transform: scale(0.9);
 }
 
 @media (max-width: 1200px) {
     .paco-posto-section {
         flex-basis: 100%; /* Em telas menores, ocupa a largura total */
         max-width: 100%;
+        min-width: unset; /* Remove min-width fixo em telas menores */
+    }
+    .main-layout-container {
+        flex-direction: column; /* Empilha os painéis em telas menores */
+        align-items: center;
+    }
+    .left-panel {
+        position: static; /* Remove sticky em telas menores */
+        max-height: unset; /* Remove max-height fixo */
+        width: 100%; /* Ocupa largura total */
     }
 }
 
@@ -1057,8 +1152,8 @@ h2 {
     position: absolute;
     top: 2px;
     left: 2px;
-    font-size: 0.6em; /* Tamanho da fonte para caber */
-    color: rgba(255, 255, 255, 0.6); /* Cor suave */
+    font-size: 1em; /* AUMENTADO: Tamanho da fonte da legenda da cavidade */
+    color: rgba(255, 255, 255, 0.9); /* AUMENTADO: Cor da fonte mais forte */
     font-weight: bold;
     z-index: 5; /* Garante que a legenda fique acima da OT */
     pointer-events: none; /* Não interfere com cliques/arrastes */


### PR DESCRIPTION
## Summary by Sourcery

Add a new "Paco-Paco" simulation page for manual OT placement, complete with a global OT palette and customizable grid per station, and enhance the main interface to launch and persist its state.

New Features:
- Introduce paco-paco.html and paco-paco-script.js to provide a standalone drag-and-drop interface for OT distribution across stations.
- Add "Ir para Paco-Paco" button in the main interface to open the new simulation page.
- Implement sessionStorage persistence for OT ordering, element HTML map, cavity contents, palette availability, and grid dimensions.

Bug Fixes:
- Ensure sessionStorage is cleared alongside localStorage when resetting state.
- Correct origin label generation logic for connectors and fix grid generation to use both column and row inputs.

Enhancements:
- Unify and extend CSS layout rules to improve responsiveness and styling for both main and Paco-Paco pages (e.g., full-width panels, flexible grid sizing, updated gap and padding).
- Add controls for grid dimensions (columns/rows) and refine drag-and-drop visual feedback and interactivity on OT elements.